### PR TITLE
Implement QR factorization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "jedvek"
-version = "0.1.1"
+version = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jedvek"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 
 description = "Multidimensional Rust vectors with a 1D footprint"

--- a/src/core/matrix2D.rs
+++ b/src/core/matrix2D.rs
@@ -229,25 +229,19 @@ impl<T> Matrix2D<T> {
         T: Copy + std::default::Default + std::ops::AddAssign + std::ops::Mul<Output = T>,
     {
         if self.height == 1 && self.width == 1 || rhs.height == 1 && rhs.width == 1 {
-            println!("Scalar mult");
-            let mut matrix = Matrix2D::new();
-            let mut scalar = T::default();
-            if rhs.height == 1 {
+            let matrix;
+            let scalar;
+            if rhs.height == 1 && rhs.width == 1 {
                 matrix = self.clone();
                 scalar = rhs[0][0];
-            } else if self.height == 1 {
+            } else {
                 matrix = rhs.clone();
                 scalar = self[0][0];
             }
 
-            println!("Matrix height and width: {}, {}", matrix.height, matrix.width);
-
             let mut result = Matrix2D::full(T::default(), matrix.height, matrix.width);
             for i in 0..matrix.height {
                 for j in 0..matrix.width {
-                    println!(
-                        "result calc"
-                    );
                     result[i][j] = scalar * matrix[i][j];
                 }
             }
@@ -1157,7 +1151,7 @@ mod tests {
         let arr1 = Matrix2D::from_flat(vec![1], 0, 1, 1).unwrap();
         let arr2 = Matrix2D::from_flat(vec![1, 0, 1], 0, 1, 3).unwrap();
 
-        let expected = Matrix2D::from_flat(vec![1, 0, 1], 0, 3, 1).unwrap();
+        let expected = Matrix2D::from_flat(vec![1, 0, 1], 0, 1, 3).unwrap();
         let res = arr1.dot(&arr2).unwrap();
         assert_eq!(res, expected);
     }

--- a/src/core/matrix2D.rs
+++ b/src/core/matrix2D.rs
@@ -229,6 +229,7 @@ impl<T> Matrix2D<T> {
         T: Copy + std::default::Default + std::ops::AddAssign + std::ops::Mul<Output = T>,
     {
         if self.height == 1 && self.width == 1 || rhs.height == 1 && rhs.width == 1 {
+            println!("Scalar mult");
             let mut matrix = Matrix2D::new();
             let mut scalar = T::default();
             if rhs.height == 1 {
@@ -239,9 +240,14 @@ impl<T> Matrix2D<T> {
                 scalar = self[0][0];
             }
 
+            println!("Matrix height and width: {}, {}", matrix.height, matrix.width);
+
             let mut result = Matrix2D::full(T::default(), matrix.height, matrix.width);
             for i in 0..matrix.height {
                 for j in 0..matrix.width {
+                    println!(
+                        "result calc"
+                    );
                     result[i][j] = scalar * matrix[i][j];
                 }
             }
@@ -1143,6 +1149,16 @@ mod tests {
         let expected = Matrix2D::from_flat(vec![8, 0, 2, -18], 0, 2, 2).unwrap();
 
         let res = scal.dot(&mat).unwrap();
+        assert_eq!(res, expected);
+    }
+
+    #[test]
+    fn test_scalar_mul_vec() {
+        let arr1 = Matrix2D::from_flat(vec![1], 0, 1, 1).unwrap();
+        let arr2 = Matrix2D::from_flat(vec![1, 0, 1], 0, 1, 3).unwrap();
+
+        let expected = Matrix2D::from_flat(vec![1, 0, 1], 0, 3, 1).unwrap();
+        let res = arr1.dot(&arr2).unwrap();
         assert_eq!(res, expected);
     }
 

--- a/src/core/matrix2D.rs
+++ b/src/core/matrix2D.rs
@@ -228,7 +228,7 @@ impl<T> Matrix2D<T> {
     where
         T: Copy + std::default::Default + std::ops::AddAssign + std::ops::Mul<Output = T>,
     {
-        if self.height == 1 && self.width == 1 || rhs.height == 1 && rhs.width == 2 {
+        if self.height == 1 && self.width == 1 || rhs.height == 1 && rhs.width == 1 {
             let mut matrix = Matrix2D::new();
             let mut scalar = T::default();
             if rhs.height == 1 {
@@ -1121,6 +1121,16 @@ mod tests {
 
         let expected = Matrix2D::from_flat(vec![83, 63, 37, 75], 0, 1, 4).unwrap();
 
+        let res = arr1.dot(&arr2).unwrap();
+        assert_eq!(res, expected);
+    }
+
+    #[test]
+    fn test_vec_mul_vec() {
+        let arr1 = Matrix2D::from_flat(vec![1, 1], 0, 2, 1).unwrap();
+        let arr2 = Matrix2D::from_flat(vec![1, 0], 0, 1, 2).unwrap();
+
+        let expected = Matrix2D::from_flat(vec![1, 0, 1, 0], 0, 2, 2).unwrap();
         let res = arr1.dot(&arr2).unwrap();
         assert_eq!(res, expected);
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -23,4 +23,5 @@ pub enum Matrix2DError {
         from: &'static str,
         to: &'static str,
     },
+    OutOfBounds,
 }

--- a/src/decomposition/mod.rs
+++ b/src/decomposition/mod.rs
@@ -1,5 +1,6 @@
 pub mod lu;
 pub mod plu;
+pub mod qr;
 
 pub use lu::lu_decomposition;
 pub use plu::lu_pivot_decomposition;
@@ -11,6 +12,7 @@ pub enum DecompositionError {
     NonSquareMatrix,
     SingularMatrix,
     InvalidVector(Matrix2DError),
+    InvalidBounds,
 }
 
 impl From<Matrix2DError> for DecompositionError {

--- a/src/decomposition/qr.rs
+++ b/src/decomposition/qr.rs
@@ -3,6 +3,7 @@ use crate::{Matrix2D, Matrix2DError};
 
 fn norm(matrix: &Matrix2D<f64>) -> f64 {
     // Assumes the matrix is 1 dimensional, i.e. a vector
+    assert!(matrix.width == 1 || matrix.height == 1);
     let mut sum: f64 = 0.0;
     for m in 0..matrix.height {
         for n in 0..matrix.width {
@@ -21,17 +22,13 @@ fn submatrix(
     wend: usize,
 ) -> Result<Matrix2D<f64>, Matrix2DError> {
     // Uses 0-indexing
-    if hstart > hend
-        || wstart > wend
-        || hend >= matrix.height
-        || wend >= matrix.width
-    {
+    if hstart > hend || wstart > wend || hend >= matrix.height || wend >= matrix.width {
         return Err(Matrix2DError::InconsistentRowLengths);
     }
 
-    // refactor matrix data
+    // Refactor matrix data
     let mut inner = Vec::<f64>::new();
-    for h in hstart..(hend + 1){
+    for h in hstart..(hend + 1) {
         for w in wstart..(wend + 1) {
             inner.push(matrix[h][w]);
         }
@@ -39,10 +36,10 @@ fn submatrix(
 
     let result = Matrix2D::from_flat(inner, 0.0, hend - hstart + 1, wend - wstart + 1);
     if let Ok(result) = result {
-        return Ok(result);
+        Ok(result)
     } else {
         println!("Error when creating result");
-        return Err(Matrix2DError::InconsistentRowLengths);
+        Err(Matrix2DError::InconsistentRowLengths)
     }
 }
 
@@ -57,7 +54,8 @@ pub fn qr_factorization<M>(matrix: M) -> Result<(Matrix2D<f64>, Matrix2D<f64>), 
 where
     M: TryInto<Matrix2D<f64>, Error = Matrix2DError>,
 {
-    // Returns the compressed form of the QR factorization
+    // Returns the non-compressed form of the QR factorization, less space efficient
+    // but returns a direct result at the end
     let mut matrix: Matrix2D<f64> = matrix.try_into()?;
     if matrix.height < matrix.width {
         return Err(DecompositionError::NonSquareMatrix);
@@ -67,83 +65,48 @@ where
 
     for j in 0..matrix.width {
         let hvec = submatrix(&matrix, j, matrix.width - 1, j, j).unwrap();
-        println!("hvec: {}", hvec);
         let normx = norm(&hvec);
-        println!("normx: {}", &normx);
         let s = -sign(matrix[j][j]);
-        println!("s: {}", &s);
         let u1 = matrix[j][j] - s * normx;
-        println!("u1 {}", &u1);
         let mut w = hvec / u1;
 
         // I can't currently think of a better way to mutate the first element
         // of an Matrix2D which doesn't have a statically defined size at compile time
         let w_iter = w.rows_mut();
-        for row in w_iter.into_iter() {
-            for elem in row {
-                *elem = 1_f64;
-                break;
-            }
-            break;
+        if let Some(row) = w_iter.into_iter().next()
+            && let Some(elem) = row.iter_mut().next()
+        {
+            *elem = 1_f64;
         }
 
-        println!("w: {}", &w);
-
-        //matrix[j+1:end, j] = w(2:end)
-
-        //matrix[j][j] = s * normx;
-
         let tau = -s * u1 / normx;
-        println!("tau: {}", tau);
 
-
-        // Now modify the original matrix
         let r_end = submatrix(&matrix, j, matrix.height - 1, 0, matrix.width - 1).unwrap();
         let q_end = submatrix(&q, 0, matrix.height - 1, j, matrix.width - 1).unwrap();
-        println!("r_end: {}", r_end);
-        println!("q_end: {}", q_end);
 
         let mut tau_w = w.clone();
         let tau_w_iter = tau_w.rows_mut();
         for row in tau_w_iter.into_iter() {
             for elem in row {
-                *elem = *elem * tau;
+                *elem *= tau;
             }
         }
-        
-        println!("tau_w: {}", tau_w);
-        println!("Getting r_end");
         let r_sub_by = (tau_w.clone()) * (w.transpose() * &r_end);
-        println!("tau_w shape: {:?}", tau_w.shape());
-        println!("w transpose: {:?}", w.transpose());
-        println!("w_transpose shape: {:?}", w.transpose().shape());
-        println!("r_end shape: {:?}", r_end.shape());
-        println!("w' * r_end: {}", (w.transpose() * &r_end));
-        println!("r sub by: {}", &r_sub_by);
-
-        println!("q_end shape: {:?}", q_end.shape());
-        println!("w shape: {:?}", w.shape());
         let q_sub_by = (q_end * w) * tau_w.transpose();
-        println!("q sub by: {}", &q_sub_by);
-        
+
         let r_sub_by_shape = r_sub_by.shape();
         let q_sub_by_shape = q_sub_by.shape();
 
-        println!("r_sub_by_shape: {:?}", r_sub_by_shape);
-        println!("q_sub_by_shape: {:?}", q_sub_by_shape);
         for row in j..matrix.height {
             for col in 0..matrix.width {
                 if row - j < r_sub_by_shape.0 && col < r_sub_by_shape.1 {
-                    matrix[row][col] = matrix[row][col] - r_sub_by[row - j][col];
+                    matrix[row][col] -= r_sub_by[row - j][col];
                 }
                 if row - j < q_sub_by_shape.1 && col < q_sub_by_shape.0 {
-                    q[col][row] = q[col][row] - q_sub_by[col][row - j];
+                    q[col][row] -= q_sub_by[col][row - j];
                 }
             }
         }
-
-        println!("q: {}", &q);
-        println!("r: {}", &matrix);
     }
 
     Ok((q, matrix))
@@ -152,6 +115,53 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    fn check_orthogonal(matrix: &Matrix2D<f64>) -> bool {
+        let mat_tol_f64 = 10.0_f64.powf(-12.0);
+        for col in 0..matrix.width {
+            for other_col in (col + 1)..matrix.width {
+                let mut product = 0_f64;
+                for row in 0..matrix.height {
+                    product += matrix[row][col] * matrix[row][other_col];
+                }
+
+                if product.abs() > mat_tol_f64 {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    fn check_upper_triangular(matrix: &Matrix2D<f64>) -> bool {
+        let mat_tol_f64 = 10.0_f64.powf(-12.0);
+        for row in 0..matrix.height {
+            for col in 0..matrix.width {
+                if row > col && matrix[row][col].abs() > mat_tol_f64 {
+                    return false;
+                } 
+            }
+        }
+        true
+    }
+
+    fn equal_within_tol(lhs: &Matrix2D<f64>, rhs: &Matrix2D<f64>) -> bool {
+        let mat_tol_f64 = 10.0_f64.powf(-12.0);
+        if lhs.height != rhs.height && lhs.width != rhs.width {
+            return false;
+        }
+        if lhs.height == 0 || rhs.height == 0 {
+            return true;
+        }
+
+        for r in 0..lhs.height {
+            for c in 0..lhs.width {
+                if (lhs[r][c] - rhs[r][c]).abs() > mat_tol_f64 {
+                    return false;
+                }
+            }
+        }
+        true
+    }
 
     #[test]
     fn basic_norm() {
@@ -173,17 +183,35 @@ mod tests {
     fn basic_qr() {
         let matr: Matrix2D<f64> = Matrix2D::from(&[[-1.0, 3.0], [1.0, 5.0]]);
         let (q, r) = qr_factorization(&matr).unwrap();
-        println!("q: {} \n r: {}", q, r);
-        let expected = q * r;
-        assert_eq!(matr, expected);
+        let expected = &q * &r;
+        assert!(check_orthogonal(&q));
+        assert!(check_upper_triangular(&r));
+        assert!(equal_within_tol(&matr, &expected));
     }
 
     #[test]
     fn qr_test_3x3() {
-        let matr: Matrix2D<f64> = Matrix2D::from(&[[2.0, -1.0, -2.0], [-4.0, 6.0, -3.0], [-4.0, -2.0, 8.0]]);
+        let matr: Matrix2D<f64> =
+            Matrix2D::from(&[[2.0, -1.0, -2.0], [-4.0, 6.0, -3.0], [-4.0, -2.0, 8.0]]);
         let (q, r) = qr_factorization(&matr).unwrap();
-        println!("q: {} \n r: {}", q, r);
-        let expected = q * r;
-        assert_eq!(matr, expected);
+        let expected = &q * &r;
+        assert!(check_orthogonal(&q));
+        assert!(check_upper_triangular(&r));
+        assert!(equal_within_tol(&matr, &expected));
+    }
+
+    #[test]
+    fn qr_test_4x4() {
+        let matr: Matrix2D<f64> = Matrix2D::from(&[
+            [1.0, -1.0, 0.0, 0.0],
+            [1.0, 1.0, 1.0, 0.0],
+            [0.0, 1.0, 1.0, 1.0],
+            [0.0, 0.0, 1.0, 1.0],
+        ]);
+        let (q, r) = qr_factorization(&matr).unwrap();
+        let expected = &q * &r;
+        assert!(check_orthogonal(&q));
+        assert!(check_upper_triangular(&r));
+        assert!(equal_within_tol(&matr, &expected));
     }
 }

--- a/src/decomposition/qr.rs
+++ b/src/decomposition/qr.rs
@@ -1,0 +1,189 @@
+use crate::decomposition::DecompositionError;
+use crate::{Matrix2D, Matrix2DError};
+
+fn norm(matrix: &Matrix2D<f64>) -> f64 {
+    // Assumes the matrix is 1 dimensional, i.e. a vector
+    let mut sum: f64 = 0.0;
+    for m in 0..matrix.height {
+        for n in 0..matrix.width {
+            sum += matrix[m][n].powi(2)
+        }
+    }
+
+    sum.sqrt()
+}
+
+fn submatrix(
+    matrix: &Matrix2D<f64>,
+    hstart: usize,
+    hend: usize,
+    wstart: usize,
+    wend: usize,
+) -> Result<Matrix2D<f64>, Matrix2DError> {
+    // Uses 0-indexing
+    if hstart > hend
+        || wstart > wend
+        || hend >= matrix.height
+        || wend >= matrix.width
+    {
+        return Err(Matrix2DError::InconsistentRowLengths);
+    }
+
+    // refactor matrix data
+    let mut inner = Vec::<f64>::new();
+    for h in hstart..(hend + 1){
+        for w in wstart..(wend + 1) {
+            inner.push(matrix[h][w]);
+        }
+    }
+
+    let result = Matrix2D::from_flat(inner, 0.0, hend - hstart + 1, wend - wstart + 1);
+    if let Ok(result) = result {
+        return Ok(result);
+    } else {
+        println!("Error when creating result");
+        return Err(Matrix2DError::InconsistentRowLengths);
+    }
+}
+
+fn sign(entry: f64) -> f64 {
+    if entry < 0.0 {
+        return -1.0;
+    }
+    1.0
+}
+
+pub fn qr_factorization<M>(matrix: M) -> Result<(Matrix2D<f64>, Matrix2D<f64>), DecompositionError>
+where
+    M: TryInto<Matrix2D<f64>, Error = Matrix2DError>,
+{
+    // Returns the compressed form of the QR factorization
+    let mut matrix: Matrix2D<f64> = matrix.try_into()?;
+    if matrix.height < matrix.width {
+        return Err(DecompositionError::NonSquareMatrix);
+    }
+
+    let mut q: Matrix2D<f64> = Matrix2D::identity(matrix.height);
+
+    for j in 0..matrix.width {
+        let hvec = submatrix(&matrix, j, matrix.width - 1, j, j).unwrap();
+        println!("hvec: {}", hvec);
+        let normx = norm(&hvec);
+        println!("normx: {}", &normx);
+        let s = -sign(matrix[j][j]);
+        println!("s: {}", &s);
+        let u1 = matrix[j][j] - s * normx;
+        println!("u1 {}", &u1);
+        let mut w = hvec / u1;
+
+        // I can't currently think of a better way to mutate the first element
+        // of an Matrix2D which doesn't have a statically defined size at compile time
+        let w_iter = w.rows_mut();
+        for row in w_iter.into_iter() {
+            for elem in row {
+                *elem = 1_f64;
+                break;
+            }
+            break;
+        }
+
+        println!("w: {}", &w);
+
+        //matrix[j+1:end, j] = w(2:end)
+
+        //matrix[j][j] = s * normx;
+
+        let tau = -s * u1 / normx;
+        println!("tau: {}", tau);
+
+
+        // Now modify the original matrix
+        let r_end = submatrix(&matrix, j, matrix.height - 1, 0, matrix.width - 1).unwrap();
+        let q_end = submatrix(&q, 0, matrix.height - 1, j, matrix.width - 1).unwrap();
+        println!("r_end: {}", r_end);
+        println!("q_end: {}", q_end);
+
+        let mut tau_w = w.clone();
+        let tau_w_iter = tau_w.rows_mut();
+        for row in tau_w_iter.into_iter() {
+            for elem in row {
+                *elem = *elem * tau;
+            }
+        }
+        
+        println!("tau_w: {}", tau_w);
+        println!("Getting r_end");
+        let r_sub_by = (tau_w.clone()) * (w.transpose() * &r_end);
+        println!("tau_w shape: {:?}", tau_w.shape());
+        println!("w transpose: {:?}", w.transpose());
+        println!("w_transpose shape: {:?}", w.transpose().shape());
+        println!("r_end shape: {:?}", r_end.shape());
+        println!("w' * r_end: {}", (w.transpose() * &r_end));
+        println!("r sub by: {}", &r_sub_by);
+
+        println!("q_end shape: {:?}", q_end.shape());
+        println!("w shape: {:?}", w.shape());
+        let q_sub_by = (q_end * w) * tau_w.transpose();
+        println!("q sub by: {}", &q_sub_by);
+        
+        let r_sub_by_shape = r_sub_by.shape();
+        let q_sub_by_shape = q_sub_by.shape();
+
+        println!("r_sub_by_shape: {:?}", r_sub_by_shape);
+        println!("q_sub_by_shape: {:?}", q_sub_by_shape);
+        for row in j..matrix.height {
+            for col in 0..matrix.width {
+                if row - j < r_sub_by_shape.0 && col < r_sub_by_shape.1 {
+                    matrix[row][col] = matrix[row][col] - r_sub_by[row - j][col];
+                }
+                if row - j < q_sub_by_shape.1 && col < q_sub_by_shape.0 {
+                    q[col][row] = q[col][row] - q_sub_by[col][row - j];
+                }
+            }
+        }
+
+        println!("q: {}", &q);
+        println!("r: {}", &matrix);
+    }
+
+    Ok((q, matrix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_norm() {
+        let vec: Matrix2D<f64> = Matrix2D::from(&[[-1.0, 3.0, 5.0]]);
+        let result = norm(&vec);
+        assert_eq!(result, 5.916079783099616);
+    }
+
+    #[test]
+    fn basic_submatrix() {
+        let vec = Matrix2D::from(&[[-1.0, 2.0, 3.0], [6.0, 5.0, 4.0]]);
+        assert_eq!(vec.shape(), (2, 3));
+        let result = submatrix(&vec, 0, 1, 1, 2).unwrap();
+        let expected: Matrix2D<f64> = Matrix2D::from(&[[2.0, 3.0], [5.0, 4.0]]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn basic_qr() {
+        let matr: Matrix2D<f64> = Matrix2D::from(&[[-1.0, 3.0], [1.0, 5.0]]);
+        let (q, r) = qr_factorization(&matr).unwrap();
+        println!("q: {} \n r: {}", q, r);
+        let expected = q * r;
+        assert_eq!(matr, expected);
+    }
+
+    #[test]
+    fn qr_test_3x3() {
+        let matr: Matrix2D<f64> = Matrix2D::from(&[[2.0, -1.0, -2.0], [-4.0, 6.0, -3.0], [-4.0, -2.0, 8.0]]);
+        let (q, r) = qr_factorization(&matr).unwrap();
+        println!("q: {} \n r: {}", q, r);
+        let expected = q * r;
+        assert_eq!(matr, expected);
+    }
+}

--- a/src/decomposition/qr.rs
+++ b/src/decomposition/qr.rs
@@ -29,8 +29,8 @@ fn submatrix(
     // Refactor matrix data
     let mut inner = Vec::<f64>::new();
     for h in hstart..(hend + 1) {
-        for w in wstart..(wend + 1) {
-            inner.push(matrix[h][w]);
+        for reflection_vec in wstart..(wend + 1) {
+            inner.push(matrix[h][reflection_vec]);
         }
     }
 
@@ -58,46 +58,48 @@ where
     let mut q: Matrix2D<f64> = Matrix2D::identity(matrix.height);
 
     for j in 0..matrix.width {
-        let hvec = submatrix(&matrix, j, matrix.width - 1, j, j).unwrap();
-        let normx = norm(&hvec);
-        let s = -sign(matrix[j][j]);
-        let u1 = matrix[j][j] - s * normx;
-        let mut w = hvec / u1;
+        let column_tail = submatrix(&matrix, j, matrix.width - 1, j, j).unwrap();
+        let column_norm = norm(&column_tail);
+        let reflection_sign = -sign(matrix[j][j]);
+        let reflection_pivot = matrix[j][j] - reflection_sign * column_norm;
+        let mut reflection_vec = column_tail / reflection_pivot;
 
         // I can't currently think of a better way to mutate the first element
         // of an Matrix2D which doesn't have a statically defined size at compile time
-        let w_iter = w.rows_mut();
-        if let Some(row) = w_iter.into_iter().next()
+        let reflection_vec_iter = reflection_vec.rows_mut();
+        if let Some(row) = reflection_vec_iter.into_iter().next()
             && let Some(elem) = row.iter_mut().next()
         {
             *elem = 1_f64;
         }
 
-        let tau = -s * u1 / normx;
+        let tau = -reflection_sign * reflection_pivot / column_norm;
 
-        let r_end = submatrix(&matrix, j, matrix.height - 1, 0, matrix.width - 1).unwrap();
-        let q_end = submatrix(&q, 0, matrix.height - 1, j, matrix.width - 1).unwrap();
+        let r_active_matrix =
+            submatrix(&matrix, j, matrix.height - 1, 0, matrix.width - 1).unwrap();
+        let q_active_matrix = submatrix(&q, 0, matrix.height - 1, j, matrix.width - 1).unwrap();
 
-        let mut tau_w = w.clone();
-        let tau_w_iter = tau_w.rows_mut();
-        for row in tau_w_iter.into_iter() {
+        let mut scaled_reflector_vec = reflection_vec.clone();
+        let scaled_reflector_vec_iter = scaled_reflector_vec.rows_mut();
+        for row in scaled_reflector_vec_iter.into_iter() {
             for elem in row {
                 *elem *= tau;
             }
         }
-        let r_sub_by = (tau_w.clone()) * (w.transpose() * &r_end);
-        let q_sub_by = (q_end * w) * tau_w.transpose();
+        let r_update_term =
+            (scaled_reflector_vec.clone()) * (reflection_vec.transpose() * &r_active_matrix);
+        let q_update_term = (q_active_matrix * reflection_vec) * scaled_reflector_vec.transpose();
 
-        let r_sub_by_shape = r_sub_by.shape();
-        let q_sub_by_shape = q_sub_by.shape();
+        let r_update_term_dim = r_update_term.shape();
+        let q_update_term_dim = q_update_term.shape();
 
         for row in j..matrix.height {
             for col in 0..matrix.width {
-                if row - j < r_sub_by_shape.0 && col < r_sub_by_shape.1 {
-                    matrix[row][col] -= r_sub_by[row - j][col];
+                if row - j < r_update_term_dim.0 && col < r_update_term_dim.1 {
+                    matrix[row][col] -= r_update_term[row - j][col];
                 }
-                if row - j < q_sub_by_shape.1 && col < q_sub_by_shape.0 {
-                    q[col][row] -= q_sub_by[col][row - j];
+                if row - j < q_update_term_dim.1 && col < q_update_term_dim.0 {
+                    q[col][row] -= q_update_term[col][row - j];
                 }
             }
         }
@@ -132,7 +134,7 @@ mod tests {
             for col in 0..matrix.width {
                 if row > col && matrix[row][col].abs() > mat_tol_f64 {
                     return false;
-                } 
+                }
             }
         }
         true
@@ -175,37 +177,58 @@ mod tests {
 
     #[test]
     fn basic_qr() {
-        let matr: Matrix2D<f64> = Matrix2D::from(&[[-1.0, 3.0], [1.0, 5.0]]);
-        let (q, r) = qr_factorization(&matr).unwrap();
-        let expected = &q * &r;
+        let matrix: Matrix2D<f64> = Matrix2D::from(&[[-1.0, 3.0], [1.0, 5.0]]);
+        let (q, r) = qr_factorization(&matrix).unwrap();
+        let original_matrix = &q * &r;
         assert!(check_orthogonal(&q));
         assert!(check_upper_triangular(&r));
-        assert!(equal_within_tol(&matr, &expected));
+        assert!(equal_within_tol(&matrix, &original_matrix));
     }
 
     #[test]
     fn qr_test_3x3() {
-        let matr: Matrix2D<f64> =
+        let matrix: Matrix2D<f64> =
             Matrix2D::from(&[[2.0, -1.0, -2.0], [-4.0, 6.0, -3.0], [-4.0, -2.0, 8.0]]);
-        let (q, r) = qr_factorization(&matr).unwrap();
-        let expected = &q * &r;
+        let (q, r) = qr_factorization(&matrix).unwrap();
+        let original_matrix = &q * &r;
         assert!(check_orthogonal(&q));
         assert!(check_upper_triangular(&r));
-        assert!(equal_within_tol(&matr, &expected));
+        assert!(equal_within_tol(&matrix, &original_matrix));
     }
 
     #[test]
     fn qr_test_4x4() {
-        let matr: Matrix2D<f64> = Matrix2D::from(&[
+        let matrix: Matrix2D<f64> = Matrix2D::from(&[
             [1.0, -1.0, 0.0, 0.0],
             [1.0, 1.0, 1.0, 0.0],
             [0.0, 1.0, 1.0, 1.0],
             [0.0, 0.0, 1.0, 1.0],
         ]);
-        let (q, r) = qr_factorization(&matr).unwrap();
-        let expected = &q * &r;
+        let (q, r) = qr_factorization(&matrix).unwrap();
+        let original_matrix = &q * &r;
         assert!(check_orthogonal(&q));
         assert!(check_upper_triangular(&r));
-        assert!(equal_within_tol(&matr, &expected));
+        assert!(equal_within_tol(&matrix, &original_matrix));
+    }
+
+    #[test]
+    fn qr_test_known_3x3() {
+        // Expected values from https://www.geeksforgeeks.org/machine-learning/qr-decomposition-in-machine-learning/
+        // As noted, QR decomp is not unique all the way down to the signs.
+        // The signs in Q can defer from another implementation as long as the
+        // corresponding sign in R is flipped.
+        // Some implementations enforce a positive diagonal BUT numpy does not.
+        // Similarly, I see no need for us to enforce a positive diagonal in the R matrix.
+        let matrix: Matrix2D<f64> = Matrix2D::from(&[[1., 2., 4.], [0., 0., 5.], [0., 3., 6.]]);
+        let (q, r) = qr_factorization(&matrix).unwrap();
+        let original_matrix = &q * &r;
+        let expected_q: Matrix2D<f64> =
+            Matrix2D::from(&[[-1., 0., 0.], [0., 0., 1.], [0., -1., 0.]]);
+        let expected_r: Matrix2D<f64> =
+            Matrix2D::from(&[[-1., -2., -4.], [0., -3., -6.], [0., 0., 5.]]);
+
+        assert_eq!(expected_q, q);
+        assert_eq!(expected_r, r);
+        assert_eq!(matrix, original_matrix);
     }
 }

--- a/src/decomposition/qr.rs
+++ b/src/decomposition/qr.rs
@@ -23,7 +23,7 @@ fn submatrix(
 ) -> Result<Matrix2D<f64>, Matrix2DError> {
     // Uses 0-indexing
     if hstart > hend || wstart > wend || hend >= matrix.height || wend >= matrix.width {
-        return Err(Matrix2DError::InconsistentRowLengths);
+        return Err(Matrix2DError::OutOfBounds);
     }
 
     // Refactor matrix data
@@ -34,13 +34,7 @@ fn submatrix(
         }
     }
 
-    let result = Matrix2D::from_flat(inner, 0.0, hend - hstart + 1, wend - wstart + 1);
-    if let Ok(result) = result {
-        Ok(result)
-    } else {
-        println!("Error when creating result");
-        Err(Matrix2DError::InconsistentRowLengths)
-    }
+    Matrix2D::from_flat(inner, 0.0, hend - hstart + 1, wend - wstart + 1)
 }
 
 fn sign(entry: f64) -> f64 {
@@ -58,7 +52,7 @@ where
     // but returns a direct result at the end
     let mut matrix: Matrix2D<f64> = matrix.try_into()?;
     if matrix.height < matrix.width {
-        return Err(DecompositionError::NonSquareMatrix);
+        return Err(DecompositionError::InvalidBounds);
     }
 
     let mut q: Matrix2D<f64> = Matrix2D::identity(matrix.height);


### PR DESCRIPTION
The base implementation and testing of the QR factorization algorithm using Householder reflections. 

For ease, I implemented functions that extract the norm out of a 1D Matrix2D and one that returns a submatrix of some Matrix2D, to make QR easier to implement. I've also created functions that check equality, check if a matrix is orthogonal and if it is upper triangular to validate the results of the QR factorization. These can likely be converted into methods and trait implementations in the core Matrix2D code, but this much serves as a good working foundation for the implementation.

I also opted not to write the compressed version of QR factorization, as this method was easier to start with, though now it's not difficult to switch over.
